### PR TITLE
deprecate `update_model_card_json()` and clean up code

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,13 @@
 
 ## Major Features and Improvements
 
+* `ModelCard.from_json()` added.
+
 ## Bug fixes and other changes
 
 ## Breaking changes and Deprecations
+
+* Complete deprecation of `ModelCardToolkit.update_model_card_json()`. Users should migrate to `ModelCardToolkit.update_model_card()`, which uses a proto representation. Alternatively, users can use `ModelCard.to_json()` and `ModelCard.from_json()` to interact with JSON representations.
 
 # Release 1.1.0
 

--- a/model_card_toolkit/documentation/README.md
+++ b/model_card_toolkit/documentation/README.md
@@ -25,7 +25,7 @@ model_card.model_details.name = 'My Model'
 mct.update_model_card(model_card)       # writes to proto
 mct.update_model_card_json(model_card)  # writes to JSON
 
-# Return the model card document as an HTML page
+# Return the model card document as an HTML page, and save to file
 html = mct.export_format()
 ```
 

--- a/model_card_toolkit/model_card.py
+++ b/model_card_toolkit/model_card.py
@@ -31,8 +31,6 @@ from model_card_toolkit.utils import validation
 _SCHEMA_VERSION_STRING = "schema_version"
 
 
-# TODO(b/181702622): Think about a smart and clean way to control the required
-# field.
 @dataclasses.dataclass
 class Owner(BaseModelCardField):
   """The information about owners of a model.
@@ -269,8 +267,6 @@ class PerformanceMetric(BaseModelCardField):
     value: What is the value of this performance metric?
     slice: What slice of your data was this metric computed on?
   """
-  # TODO(b/179415408): add fields (name, value, confidence_interval, threshold,
-  # slice) after gathering requirements (potential clients: Jigsaw)
   # The following fields are EXPERIMENTAL and introduced for migration purpose.
   type: Optional[Text] = None
   value: Optional[Text] = None
@@ -445,21 +441,15 @@ class ModelCard(BaseModelCardField):
         _SCHEMA_VERSION_STRING] = validation.get_latest_schema_version()
     return json_lib.dumps(model_card_dict, indent=2)
 
-  def _from_json(self, json_dict: Dict[Text, Any]) -> "ModelCard":
-    """Read ModelCard from JSON.
+  def from_json(self, json_dict: Dict[Text, Any]) -> None:
+    """Reads ModelCard from JSON.
 
     If ModelCard fields have already been set, this function will overwrite any
     existing values.
 
-    WARNING: This method's interface may change in the future, do not use for
-    critical workflows.
-
     Args:
       json_dict: A JSON dict from which to populate fields in the model card
         schema.
-
-    Returns:
-      self
 
     Raises:
       JSONDecodeError: If `json_dict` is not a valid JSON string.
@@ -497,4 +487,3 @@ class ModelCard(BaseModelCardField):
     validation.validate_json_schema(json_dict)
     self.clear()
     _populate_from_json(json_dict, self)
-    return self

--- a/model_card_toolkit/model_card_test.py
+++ b/model_card_toolkit/model_card_test.py
@@ -137,7 +137,8 @@ class ModelCardTest(absltest.TestCase):
 
   def test_from_json_and_to_json_with_all_fields(self):
     want_json = json.loads(_FULL_JSON)
-    model_card_py = model_card.ModelCard()._from_json(want_json)
+    model_card_py = model_card.ModelCard()
+    model_card_py.from_json(want_json)
     got_json = json.loads(model_card_py.to_json())
     self.assertEqual(want_json, got_json)
 
@@ -148,14 +149,14 @@ class ModelCardTest(absltest.TestCase):
         considerations=model_card.Considerations(
             limitations=[overwritten_limitation]))
     model_card_json = json.loads(_FULL_JSON)
-    model_card_py = model_card_py._from_json(model_card_json)
+    model_card_py.from_json(model_card_json)
     self.assertNotIn(overwritten_limitation,
                      model_card_py.considerations.limitations)
 
   def test_from_invalid_json(self):
     invalid_json_dict = {"model_name": "the_greatest_model"}
     with self.assertRaises(jsonschema.ValidationError):
-      model_card.ModelCard()._from_json(invalid_json_dict)
+      model_card.ModelCard().from_json(invalid_json_dict)
 
   def test_from_invalid_json_vesion(self):
     model_card_dict = {
@@ -168,7 +169,7 @@ class ModelCardTest(absltest.TestCase):
     with self.assertRaisesRegex(ValueError, (
         "^Cannot find schema version that matches the version of the given "
         "model card.")):
-      model_card.ModelCard()._from_json(model_card_dict)
+      model_card.ModelCard().from_json(model_card_dict)
 
   def test_from_proto_to_json(self):
     model_card_proto = text_format.Parse(_FULL_PROTO,
@@ -189,7 +190,8 @@ class ModelCardTest(absltest.TestCase):
                                          model_card_pb2.ModelCard())
 
     model_card_json = json.loads(_FULL_JSON)
-    model_card_py = model_card.ModelCard()._from_json(model_card_json)
+    model_card_py = model_card.ModelCard()
+    model_card_py.from_json(model_card_json)
     model_card_json2proto = model_card_py.to_proto()
 
     self.assertEqual(model_card_proto, model_card_json2proto)

--- a/model_card_toolkit/utils/graphics_test.py
+++ b/model_card_toolkit/utils/graphics_test.py
@@ -38,7 +38,7 @@ class GraphicsTest(parameterized.TestCase):
     self.assertEqual(g.name, h.name)
     self.assertEqual(g.color, h.color)
 
-  def test_generate_graph_from_feature_statistics(self):
+  def test_extract_graph_data_from_dataset_feature_statistics(self):
     numeric_feature_stats = text_format.Parse(
         """
         path {
@@ -60,7 +60,8 @@ class GraphicsTest(parameterized.TestCase):
           }
         }""", statistics_pb2.FeatureNameStatistics())
     self.assertGraphEqual(
-        graphics._generate_graph_from_feature_statistics(numeric_feature_stats),
+        graphics._extract_graph_data_from_dataset_feature_statistics(
+            numeric_feature_stats),
         graphics._Graph(
             x=[6, 4],
             y=['0.00-50.00', '50.00-100.00'],
@@ -92,7 +93,8 @@ class GraphicsTest(parameterized.TestCase):
           }
         }""", statistics_pb2.FeatureNameStatistics())
     self.assertGraphEqual(
-        graphics._generate_graph_from_feature_statistics(string_feature_stats),
+        graphics._extract_graph_data_from_dataset_feature_statistics(
+            string_feature_stats),
         graphics._Graph(
             x=[1387, 3395, 2395],
             y=['News', 'Tech', 'Sports'],
@@ -109,7 +111,8 @@ class GraphicsTest(parameterized.TestCase):
         type: BYTES
         bytes_stats {}""", statistics_pb2.FeatureNameStatistics())
     self.assertIsNone(
-        graphics._generate_graph_from_feature_statistics(bytes_feature_stats))
+        graphics._extract_graph_data_from_dataset_feature_statistics(
+            bytes_feature_stats))
 
     struct_feature_stats = text_format.Parse(
         """
@@ -119,7 +122,8 @@ class GraphicsTest(parameterized.TestCase):
         type: STRUCT
         struct_stats {}""", statistics_pb2.FeatureNameStatistics())
     self.assertIsNone(
-        graphics._generate_graph_from_feature_statistics(struct_feature_stats))
+        graphics._extract_graph_data_from_dataset_feature_statistics(
+            struct_feature_stats))
 
   def test_annotate_dataset_feature_statistics_plots(self):
     train_stats = text_format.Parse(
@@ -298,23 +302,19 @@ class GraphicsTest(parameterized.TestCase):
     self.assertLen(model_card.model_parameters.data, 2)
 
     train_data = model_card.model_parameters.data[0]
-    self.assertSameElements([
-        g.name
-        for g in train_data.graphics.collection
-    ], expected_plot_names_train)
+    self.assertSameElements([g.name for g in train_data.graphics.collection],
+                            expected_plot_names_train)
 
     eval_data = model_card.model_parameters.data[1]
-    self.assertSameElements([
-        g.name
-        for g in eval_data.graphics.collection
-    ], expected_plot_names_eval)
+    self.assertSameElements([g.name for g in eval_data.graphics.collection],
+                            expected_plot_names_eval)
 
     graphs = train_data.graphics.collection + eval_data.graphics.collection
     for graph in graphs:
       logging.info('%s: %s', graph.name, graph.image)
       self.assertNotEmpty(graph.image, f'feature {graph.name} has empty plot')
 
-  def test_generate_graph_from_slicing_metrics(self):
+  def test_extract_graph_data_from_slicing_metrics(self):
     slicing_metrics = [
         ((('weekday', 0),), {
             '': {
@@ -386,8 +386,8 @@ class GraphicsTest(parameterized.TestCase):
         })
     ]
     self.assertGraphEqual(
-        graphics._generate_graph_from_slicing_metrics(slicing_metrics,
-                                                      'average_loss'),
+        graphics._extract_graph_data_from_slicing_metrics(
+            slicing_metrics, 'average_loss'),
         graphics._Graph(
             x=[
                 0.07875693589448929, 4.4887189865112305, 2.092138290405273,
@@ -400,9 +400,8 @@ class GraphicsTest(parameterized.TestCase):
             name='average_loss',
             color='#A142F4'))
     self.assertGraphEqual(
-        graphics._generate_graph_from_slicing_metrics(slicing_metrics,
-                                                      'average_loss',
-                                                      'weekday'),
+        graphics._extract_graph_data_from_slicing_metrics(
+            slicing_metrics, 'average_loss', 'weekday'),
         graphics._Graph(
             x=[
                 0.07875693589448929, 4.4887189865112305, 2.092138290405273,
@@ -415,8 +414,8 @@ class GraphicsTest(parameterized.TestCase):
             name='average_loss | weekday',
             color='#A142F4'))
     self.assertGraphEqual(
-        graphics._generate_graph_from_slicing_metrics(slicing_metrics,
-                                                      'prediction/mean'),
+        graphics._extract_graph_data_from_slicing_metrics(
+            slicing_metrics, 'prediction/mean'),
         graphics._Graph(
             x=[
                 0.5100112557411194, 0.4839990735054016, 0.3767518997192383,
@@ -432,9 +431,8 @@ class GraphicsTest(parameterized.TestCase):
             color='#A142F4'))
 
     self.assertGraphEqual(
-        graphics._generate_graph_from_slicing_metrics(slicing_metrics,
-                                                      'prediction/mean',
-                                                      'weekday'),
+        graphics._extract_graph_data_from_slicing_metrics(
+            slicing_metrics, 'prediction/mean', 'weekday'),
         graphics._Graph(
             x=[
                 0.5100112557411194, 0.4839990735054016, 0.3767518997192383,


### PR DESCRIPTION
This commit introduces the following changes:
* improve docstrings and comments
* remove deprecated TODOs
* remove unnecessary imports
* updating some constants for consistency
* complete deprecation of `update_model_card_json()` (previously marked for deprecation in MCT 1.0.0 release)
* make `ModelCard.from_json()` a public API function

PiperOrigin-RevId: 398704781